### PR TITLE
Bundle wine

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -152,11 +152,6 @@ modules:
             url: "https://github.com/python-pillow/Pillow/archive/5.4.1.tar.gz"
             sha256: d233c2e63414535281c572d2b4debd7de8a205b341ffc7db0f48f3f4d199fbc0
 
-  - name: lutris-app-environment
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/lib/i386-linux-gnu
-
   - name: hwdata
     config-opts:
       - --datarootdir=/app/share
@@ -275,3 +270,8 @@ modules:
       - type: archive
         url: "http://deb.debian.org/debian/pool/main/f/fluid-soundfont/fluid-soundfont_3.1.orig.tar.gz"
         md5: 189bbdf70221018cbda536984b105dfa
+
+  - name: lutris-app-environment
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/lib/i386-linux-gnu

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -43,6 +43,14 @@ add-extensions:
     download-if: active-gl-driver
     enable-if: active-gl-driver
 
+  net.lutris.Lutris.wine:
+    directory: wine
+    add-ld-path: lib
+
+  net.lutris.Lutris.wine.compat32:
+    directory: wine/compat32
+    add-ld-path: lib
+
 cleanup:
   - "*.a"
   - "*.la"
@@ -275,3 +283,4 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/lib/i386-linux-gnu
+      - mkdir -p /app/wine

--- a/wine/net.lutris.Lutris.wine.metainfo.xml
+++ b/wine/net.lutris.Lutris.wine.metainfo.xml
@@ -3,7 +3,11 @@
   <id>net.lutris.Lutris.wine</id>
   <extends>net.lutris.Lutris</extends>
   <name>Wine for Lutris</name>
+  <name xml:lang="pt_BR">Wine para Lutris</name>
+  <name xml:lang="es">Wine para Lutris</name>
   <summary>Wine from Tk-Glitch (with staging, esync and pba patches)</summary>
+  <summary xml:lang="pt_BR">Wine de Tk-Glitch (with staging, esync and pba patches)</summary>
+  <summary xml:lang="es">Wine de Tk-Glitch (with staging, esync and pba patches)</summary>
   <url type="homepage">https://github.com/lutris/wine</url>
   <project_license>LGPL-2.1</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/wine/net.lutris.Lutris.wine.metainfo.xml
+++ b/wine/net.lutris.Lutris.wine.metainfo.xml
@@ -6,8 +6,8 @@
   <name xml:lang="pt_BR">Wine para Lutris</name>
   <name xml:lang="es">Wine para Lutris</name>
   <summary>Wine from Tk-Glitch (with staging, esync and pba patches)</summary>
-  <summary xml:lang="pt_BR">Wine de Tk-Glitch (with staging, esync and pba patches)</summary>
-  <summary xml:lang="es">Wine de Tk-Glitch (with staging, esync and pba patches)</summary>
+  <summary xml:lang="pt_BR">Wine de Tk-Glitch (with staging, esync e pba patches)</summary>
+  <summary xml:lang="es">Wine de Tk-Glitch (with staging, esync y pba patches)</summary>
   <url type="homepage">https://github.com/lutris/wine</url>
   <project_license>LGPL-2.1</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/wine/net.lutris.Lutris.wine.metainfo.xml
+++ b/wine/net.lutris.Lutris.wine.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>net.lutris.Lutris.wine</id>
+  <extends>net.lutris.Lutris</extends>
+  <name>Wine for Lutris</name>
+  <summary>Wine from Tk-Glitch (with staging, esync and pba patches)</summary>
+  <url type="homepage">https://github.com/lutris/wine</url>
+  <project_license>LGPL-2.1</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+</component>

--- a/wine/net.lutris.Lutris.wine.yml
+++ b/wine/net.lutris.Lutris.wine.yml
@@ -69,3 +69,12 @@ modules:
       - ln -srv $FLATPAK_DEST/compat32/bin/wine $FLATPAK_DEST/bin/wine
       - ln -srv $FLATPAK_DEST/compat32/bin/wine-preloader $FLATPAK_DEST/bin/wine-preloader
       - ln -srv $FLATPAK_DEST/compat32/bin/wineserver32 $FLATPAK_DEST/bin/wineserver32
+
+  - name: appdata
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+    sources:
+      - type: file
+        path: net.lutris.Lutris.wine.metainfo.xml

--- a/wine/net.lutris.Lutris.wine.yml
+++ b/wine/net.lutris.Lutris.wine.yml
@@ -1,6 +1,6 @@
 id: net.lutris.Lutris.wine
 runtime: net.lutris.Lutris
-sdk: org.freedesktop.Sdk//18.08
+sdk: org.gnome.Sdk//3.32
 build-extension: true
 separate-locales: false
 appstream-compose: false

--- a/wine/net.lutris.Lutris.wine.yml
+++ b/wine/net.lutris.Lutris.wine.yml
@@ -1,0 +1,71 @@
+id: net.lutris.Lutris.wine
+runtime: net.lutris.Lutris
+sdk: org.freedesktop.Sdk//18.08
+build-extension: true
+separate-locales: false
+appstream-compose: false
+build-options:
+    prefix: /app/wine
+    append-path: /app/wine/bin
+    append-ld-library-path: /app/lib
+    strip: true
+    no-debuginfo: false
+cleanup:
+  - /include
+  - /share/man
+  - /share/applications
+modules:
+
+  - name: wine
+    build-options:
+      config-opts:
+        - --libdir=/app/wine/lib
+      arch:
+        x86_64:
+          config-opts:
+            - --enable-win64
+    config-opts:
+      - --disable-win16
+      - --disable-tests
+      - --with-x
+      - --with-pulse
+      - --without-hal
+    post-install:
+      - case $FLATPAK_ARCH in
+          x86_64)
+            mv $FLATPAK_DEST/bin/wineserver{,64}
+          ;;
+          i386)
+            mv $FLATPAK_DEST/bin/wineserver{,32}
+          ;;
+        esac
+    cleanup:
+      - /share/man
+      - /share/applications
+    sources:
+      - type: git
+        url: "https://github.com/lutris/wine.git"
+        branch: tkg
+
+  - name: wineserver
+    buildsystem: simple
+    build-commands:
+      - ln -s $FLATPAK_DEST/wineserver $FLATPAK_DEST/bin/wineserver
+      - case $FLATPAK_ARCH in
+          x86_64)
+            ln -s bin/wineserver64 $FLATPAK_DEST/wineserver
+          ;;
+          i386)
+            ln -s bin/wineserver32 $FLATPAK_DEST/wineserver
+          ;;
+        esac
+
+  - name: compat32
+    only-arches:
+      - x86_64
+    buildsystem: simple
+    build-commands:
+      - mkdir -p $FLATPAK_DEST/compat32
+      - ln -srv $FLATPAK_DEST/compat32/bin/wine $FLATPAK_DEST/bin/wine
+      - ln -srv $FLATPAK_DEST/compat32/bin/wine-preloader $FLATPAK_DEST/bin/wine-preloader
+      - ln -srv $FLATPAK_DEST/compat32/bin/wineserver32 $FLATPAK_DEST/bin/wineserver32

--- a/wine/net.lutris.Lutris.wine.yml
+++ b/wine/net.lutris.Lutris.wine.yml
@@ -6,14 +6,22 @@ separate-locales: false
 appstream-compose: false
 build-options:
     prefix: /app/wine
-    append-path: /app/wine/bin
-    append-ld-library-path: /app/lib
+    prepend-path: /app/wine/bin
+    prepend-ld-library-path: /app/wine/lib
+    prepend-pkg-config-path: /app/wine/lib/pkgconfig
+    env:
+      C_INCLUDE_PATH: /app/wine/include:/app/include
+      CPLUS_INCLUDE_PATH: /app/wine/include:/app/include
     strip: true
     no-debuginfo: false
 cleanup:
+  - "*.a"
+  - "*.la"
   - /include
   - /share/man
   - /share/applications
+  - /lib/pkgconfig
+  - /lib/cmake
 modules:
 
   - name: wine
@@ -46,6 +54,30 @@ modules:
       - type: git
         url: "https://github.com/lutris/wine.git"
         branch: tkg
+    modules:
+
+      - name: vkd3d
+        sources:
+          - type: archive
+            url: "https://dl.winehq.org/vkd3d/source/vkd3d-1.1.tar.xz"
+            sha256: 495adc61cc80c65d54b2f5b52092ea05d3797cc2c17a610f0fc98457d2f56ab6
+        modules:
+
+          - name: SPIRV-Headers
+            buildsystem: cmake-ninja
+            sources:
+              - type: git
+                url: "https://github.com/KhronosGroup/SPIRV-Headers.git"
+                commit: 8bea0a266ac9b718aa0818d9e3a47c0b77c2cb23
+
+      - name: FAudio
+        buildsystem: cmake-ninja
+        config-opts:
+          - -DFFMPEG=ON
+        sources:
+          - type: archive
+            url: "https://github.com/FNA-XNA/FAudio/archive/19.02.tar.gz"
+            sha256: 514dd03672aa0241a7eee29e207a594e86cc9954940205489a8299cd1395ffaf
 
   - name: wineserver
     buildsystem: simple


### PR DESCRIPTION
This is an example of how we can bundle wine. Making it an extension gives some advantages. Specifically it can be updated separately from Lutris and makes multiarch builds slightly easier. 