### PR TITLE
Add mesa-demos (provides glxinfo)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -204,6 +204,27 @@ modules:
         url: "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.0.tar.bz2"
         sha256: c1cfd4e1d4d708c031d60801e527abc9b6d34b85f2ffa2cadd21f75ff38151cd
 
+  - name: mesa-demos
+    config-opts:
+      - --without-glut
+      - --bindir=/app/lib/mesa-demos
+    make-args:
+      - -C
+      - src/xdemos
+      - glxinfo
+    no-make-install: true
+    build-commands:
+      - install -D src/xdemos/glxinfo -t /app/bin/
+    sources:
+      - type: archive
+        url: "https://mesa.freedesktop.org/archive/demos/8.3.0/mesa-demos-8.3.0.tar.bz2"
+        sha256: c173154bbd0d5fb53d732471984def42fb1b14ac85fcb834138fb9518b3e0bef
+    cleanup:
+      - /lib/mesa-demos
+    modules:
+      - shared-modules/glew/glew.json
+      - shared-modules/glu/glu-9.0.0.json
+
   - name: p7zip
     no-autogen: true
     make-args:


### PR DESCRIPTION
Seems like Lutris uses `glxinfo` to get GPU info if it can't ask the WM.