### PR TITLE
Switch to freedesktop.org runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ To compile Lutris as a Flatpak, you'll need both [Flatpak](https://flatpak.org/)
 1. Add the platform dependencies...
   ```
   flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-  flatpak install --user flathub org.gnome.Sdk//3.32
-  flatpak install --user flathub org.gnome.Platform//3.32
+  flatpak install --user flathub org.freedesktop//18.08
+  flatpak install --user flathub org.freedesktop.Platform//18.08
   ```
 
 2. Compile and install the Flatpak...
@@ -32,7 +32,3 @@ flatpak uninstall --user net.lutris.Lutris
 rm -rf ~/.var/app/net.lutris.Lutris .flatpak-builder
 flatpak remote-delete lutris
 ```
-
-## Development
-
-- Python packages are built with [Flatpak PIP Generator](https://github.com/flatpak/flatpak-builder-tools/tree/master/pip)

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -1,7 +1,7 @@
 id: net.lutris.Lutris
-sdk: org.gnome.Sdk
-runtime: org.gnome.Platform
-runtime-version: "3.32"
+sdk: org.freedesktop.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: "18.08"
 command: lutris
 rename-icon: lutris
 copy-icon: true
@@ -70,6 +70,64 @@ modules:
       - type: patch
         path: patches/0002-Use-xdg-open-to-run-Steam-games-if-running-in-flatpa.patch
     modules:
+
+      - name: pygobject
+        buildsystem: meson
+        sources:
+          - type: archive
+            url: "https://download.gnome.org/sources/pygobject/3.32/pygobject-3.32.0.tar.xz"
+            sha256: 83f4d7e59fde6bc6b0d39c5e5208574802f759bc525a4cb8e7265dfcba45ef29
+        modules:
+
+          - name: pycairo
+            buildsystem: meson
+            sources:
+              - type: archive
+                url: "https://github.com/pygobject/pycairo/archive/v1.18.0.tar.gz"
+                sha256: 5320b5d760088526ff74c537f597ee21fc77a5bc5ee4e4df85a339d2d58fef6c
+
+      - name: webkitgtk
+        buildsystem: cmake-ninja
+        builddir: true
+        config-opts:
+          - -DPORT=GTK
+          - -DCMAKE_BUILD_TYPE=Release
+          - -DENABLE_PLUGIN_PROCESS_GTK2=OFF
+          - -DENABLE_GTKDOC=OFF
+          - -DENABLE_MINIBROWSER=OFF
+          - -DUSE_WOFF2=OFF
+          - -DPYTHON_EXECUTABLE=/usr/bin/python3
+        sources:
+          - type: archive
+            url: "http://webkitgtk.org/releases/webkitgtk-2.24.0.tar.xz"
+            sha256: 2e4ad1503fe482ceb5a83cf70ac9cd42f37eb718555a4d6844fe4c59a9214407
+        modules:
+
+          - name: libsecret
+            sources:
+              - type: archive
+                url: "https://download.gnome.org/sources/libsecret/0.18/libsecret-0.18.8.tar.xz"
+                sha256: 3bfa889d260e0dbabcf5b9967f2aae12edcd2ddc9adc365de7a5cc840c311d15
+
+          - name: enchant
+            sources:
+              - type: archive
+                url: "https://github.com/AbiWord/enchant/releases/download/v2.2.3/enchant-2.2.3.tar.gz"
+                sha256: abd8e915675cff54c0d4da5029d95c528362266557c61c7149d53fa069b8076d
+
+          - name: libnotify
+            sources:
+              - type: archive
+                url: "https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.7.tar.xz"
+                sha256: 9cb4ce315b2655860c524d46b56010874214ec27e854086c1a1d0260137efc04
+
+          - name: openjpeg
+            buildsystem: cmake-ninja
+            builddir: true
+            sources:
+              - type: archive
+                url: "https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz"
+                sha256: 3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a
 
       - name: gnome-desktop
         buildsystem: meson


### PR DESCRIPTION
As @valentindavid noted in https://github.com/flathub/flathub/pull/926#issuecomment-478542455, using Gnome runtime with FD.o compat32 extension can produce problems.
Switching to FD.o runtime and bundling dependencies from Gnome runtime can be worth doing.