### PR TITLE
wine: Add permission to ~/.wine

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -19,6 +19,7 @@ finish-args:
   - --filesystem=xdg-run/dconf
   - --filesystem=xdg-config/dconf:ro
   - --filesystem=~/Games:create
+  - --filesystem=~/.wine:create
   - --filesystem=xdg-data/Steam:ro
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
 add-extensions:

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -19,7 +19,7 @@ finish-args:
   - --filesystem=xdg-run/dconf
   - --filesystem=xdg-config/dconf:ro
   - --filesystem=~/Games:create
-  - --filesystem=~/.wine:create
+  - --persist=~/.wine
   - --filesystem=xdg-data/Steam:ro
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
 add-extensions:


### PR DESCRIPTION
Not entirely sure this is the correct way to address this one. Exposing the .wine config directly will allow Lutris to access the global .wine prefix.

Fixes #20