### PR TITLE
Allow development-oriented syscalls

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -13,6 +13,7 @@ finish-args:
   - --device=all
   - --share=network
   - --allow=multiarch
+  - --allow=devel
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.DisplayConfig
   - --talk-name=ca.desrt.dconf


### PR DESCRIPTION
I'm not familiar with seccomp, but I can guess Blizzard games are doing something for which Wine uses syscalls filtered by default, but allowed in development environment.
Also it seems like this is needed to allow wine getting stacktraces.
Fixes #18 