### PR TITLE
Temporarily remove i386 from the build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "only-arches": ["x86_64", "i386"]
+    "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Fixes #27 :
https://github.com/flathub/org.qgis.qgis/commit/e22f74d369a475d043dcabb610c14c95655c731f 

Note: This is just a temporary fix until the build server issue can be resolved.