### PR TITLE
Add extension point for runners

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -23,6 +23,7 @@ finish-args:
   - --persist=~/.wine
   - --filesystem=xdg-data/Steam:ro
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
+  - --env=PATH=/app/bin:/app/runners/bin:/usr/bin
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
@@ -49,7 +50,8 @@ add-extensions:
     directory: runners
     subdirectories: true
     add-ld-path: lib
-    add-path: bin
+    #FIXME: it may be not safe to merge /bin
+    merge-dirs: bin
 
 cleanup:
   - "*.a"

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -45,6 +45,12 @@ add-extensions:
     download-if: active-gl-driver
     enable-if: active-gl-driver
 
+  net.lutris.Lutris.Runner:
+    directory: runners
+    subdirectories: true
+    add-ld-path: lib
+    add-path: bin
+
 cleanup:
   - "*.a"
   - "*.la"
@@ -362,3 +368,4 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/lib/i386-linux-gnu
+      - mkdir -p /app/runners

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -218,11 +218,6 @@ modules:
             url: "https://github.com/python-pillow/Pillow/archive/6.0.0.tar.gz"
             sha256: f0babf5d7072ea9923a3950cd7ea41b0008429b16584de7d95cc5550a2806cda
 
-  - name: lutris-app-environment
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/lib/i386-linux-gnu
-
   - name: hwdata
     config-opts:
       - --datarootdir=/app/share
@@ -362,3 +357,8 @@ modules:
       - type: archive
         url: "http://deb.debian.org/debian/pool/main/f/fluid-soundfont/fluid-soundfont_3.1.orig.tar.gz"
         md5: 189bbdf70221018cbda536984b105dfa
+
+  - name: lutris-app-environment
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/lib/i386-linux-gnu

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -50,7 +50,6 @@ add-extensions:
     directory: runners
     subdirectories: true
     add-ld-path: lib
-    #FIXME: it may be not safe to merge /bin
     merge-dirs: bin
 
 cleanup:


### PR DESCRIPTION
With this we can build external programs (i.e. Lutris runners) as flatpak extensions.
Discovered problems:
- [ ] Different runners use different libs, all of them are added to ld path. This may break something.
- [ ] Lutris seems unable to detect installed runner, even when it's in PATH. Manually setting path to runner binary works.
